### PR TITLE
Update more-itertools to 8.9.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "more-itertools" %}
-{% set version = "8.8.0" %}
+{% set version = "8.9.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 83f0308e05477c68f56ea3a888172c78ed5d5b3c282addb67508e7ba6c8f813a
+  sha256: 8c746e0d09871661520da4f1241ba6b908dc903839733c8203b552cffaf173bd
 
 build:
   number: 0


### PR DESCRIPTION
1. verify the upstream 
  
  bug fixes and additions were made to the packages
  no breaking changes were mentioned
  https://github.com/more-itertools/more-itertools/blob/master/docs/versions.rst

   New functions
      :func:`interleave_evenly` (thanks to mbugert)
      :func:`repeat_each` (thanks to FinalSh4re)
      :func:`chunked_even` (thanks to valtron)
      :func:`map_if` (thanks to sassbalint)
      :func:`zip_broadcast` (thanks to kalekundert)

  Changes to existing functions
      The type stub for :func:`chunked` was improved (thanks to PhilMacKay)
      The type stubs for :func:`zip_equal` and zip_offset were improved (thanks to maffoo)
      Building Sphinx docs locally was improved (thanks to MarcinKonowalczyk)

2. check the pinnings
3. check dev_url
4. check the doc_url
5. verify that pip checked
6. verify the test section
7. additional research

 there were no open issues in conda-forge
 https://github.com/conda-forge/more-itertools-feedstock/issues

8. additional tests

   The following command was used for testing `conda-build more-itertools-feedstock --test`
   The result was the following `All tests passed`

   In order to test `more-itertools` we used `pytest` since it makes use of `more-itertools`. 
   To complete the test the package we will use the following command: `conda-build pytest-feedstock --test`
    The result is as follows: `All tests passed`

 based on our research and test results we can conclude that it is safe to update more-itertools to version 8.9.0
