### PR TITLE
more-itertools 8.10.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<35]
   noarch: python
   script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
 


### PR DESCRIPTION
Update more-itertools to 8.10.0

Category:  anaconda | subcategory:   | pkg_type:  python
Popularity:  7735247 downloads -  more-itertools  8.10.0  More routines for operating on iterables, beyond itertools
Version change: bump version number from 8.9.0 to 8.10.0
  license: MIT
Release date:  Sep 17, 2021
Bug Tracker: new open issues https://github.com/more-itertools/more-itertools/issues
Changelog: https://github.com/more-itertools/more-itertools/blob/v8.10.0/docs/versions.rst
License file:  https://github.com/more-itertools/more-itertools/blob/master/LICENSE
Upstream setup.py:  https://github.com/more-itertools/more-itertools/blob/v8.10.0/setup.py

The package more-itertools is mentioned inside the packages:
cheroot | cherrypy | jaraco.classes | jaraco.functools | jaraco.itertools | moto | pytest | quandl |

Actions:
1. Fix python in host
2. Add `python <3.10` to test/requires

Result:
- all-succeeded
