### PR TITLE
more-itertools 8.12.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "more-itertools" %}
-{% set version = "8.10.0" %}
+{% set version = "8.12.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1debcabeb1df793814859d64a81ad7cb10504c24349368ccf214c664c474f41f
+  sha256: 7dc6ad46f05f545f900dd59e8dfb4e84a4827b97b3cfecb175ea0c7d247f6064
 
 build:
   number: 0


### PR DESCRIPTION
Update more-itertools to 8.12.0

Version change: bump version number from 8.10.0 to 8.12.0
Bug Tracker: new open issues https://github.com/more-itertools/more-itertools/issues
Upstream license:  License file:  https://github.com/more-itertools/more-itertools/blob/master/LICENSE
Upstream setup.py:  https://github.com/more-itertools/more-itertools/blob/v8.12.0/setup.py

The package more-itertools is mentioned inside the packages:
cheroot | cherrypy | jaraco.classes | jaraco.functools | jaraco.itertools |  moto | pytest | quandl |

Actions:
1. No actions

Result:
- all-succeeded