### PR TITLE
more-itertools 10.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "more-itertools" %}
-{% set version = "10.1.0" %}
+{% set version = "10.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 626c369fa0eb37bac0291bce8259b332fd59ac792fa5497b59837309cd5b114a
+  sha256: e5d93ef411224fbcef366a6e8ddc4c5781bc6359d43412a65dd5964e46111463
 
 build:
   number: 0
@@ -16,7 +16,7 @@ build:
 
 requirements:
   host:
-    - flit-core
+    - flit-core >=3.2,<4
     - pip
     - python
   run:
@@ -27,8 +27,12 @@ test:
     - more_itertools
   commands:
     - pip check
+    - python -m unittest discover --buffer -s=tests
   requires:
     - pip
+    - python
+  source_files:
+    - tests
 
 about:
   home: https://github.com/more-itertools/more-itertools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,6 @@ test:
     - python -m unittest discover --buffer -s=tests
   requires:
     - pip
-    - python
   source_files:
     - tests
 


### PR DESCRIPTION
more-itertools 10.3.0

**Destination channel:** defaults

### Links

- [PKG-4764](https://anaconda.atlassian.net/browse/PKG-4764) 
- [Upstream repository](https://github.com/more-itertools/more-itertools/tree/v10.3.0)

### Explanation of changes:

- Updated version
- Specified required flit version
- Added upstream tests


[PKG-4764]: https://anaconda.atlassian.net/browse/PKG-4764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ