### PR TITLE
more-itertools 11.0.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<39]
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "more-itertools" %}
-{% set version = "11.0.1" %}
+{% set version = "11.0.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: fefaf25b7ab08f0b45fa9f1892cae93b9fc0089ef034d39213bce15f1cc9e199
+  sha256: 392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "more-itertools" %}
-{% set version = "10.8.0" %}
+{% set version = "11.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd
+  sha256: fefaf25b7ab08f0b45fa9f1892cae93b9fc0089ef034d39213bce15f1cc9e199
 
 build:
   number: 0


### PR DESCRIPTION
more-itertools 11.0.2 

**Destination channel:** Defaults

### Links

- [PKG-13388]
- dev_url:        https://github.com/more-itertools/more-itertools
- conda_forge:    https://github.com/conda-forge/more-itertools-feedstock
- pypi:           https://pypi.org/project/more-itertools/11.0.2
- pypi inspector: https://inspector.pypi.io/project/more-itertools/11.0.2

### Explanation of changes:

- new version number


[PKG-13388]: https://anaconda.atlassian.net/browse/PKG-13388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ